### PR TITLE
🐛 Fix search bug

### DIFF
--- a/src/main/java/org/likelion/newsfactbackend/domain/news/service/impl/NewsServiceImpl.java
+++ b/src/main/java/org/likelion/newsfactbackend/domain/news/service/impl/NewsServiceImpl.java
@@ -56,7 +56,16 @@ public class NewsServiceImpl implements NewsService {
     private List<String> SIDS;
 
     private static final String BASE_URL = "https://search.naver.com/search.naver?where=news&query={search}&sm=tab_opt&sort=1&photo=0&field=0&pd=0&ds=&de=&docid=&related=0&mynews=1&office_type=1&office_section_code=3&news_office_checked={oid}&nso=so%3Add%2Cp%3Aall&is_sug_officeid=0&office_category=0&service_area=0";
-    private static final String USER_AGENT = "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.110 Safari/537.3";
+    private static final List<String> USER_AGENTS = List.of(
+            "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.110 Safari/537.3",
+            "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/69.0.3497.100 Safari/537.36",
+            "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.77 Safari/537.36"
+    );
+
+    private String getRandomUserAgent() {
+        Random rand = new Random();
+        return USER_AGENTS.get(rand.nextInt(USER_AGENTS.size()));
+    }
     private static final int TIMEOUT = 10000; // 10초
     private static final int RETRY_COUNT = 3; // 재시도 횟수
 
@@ -95,7 +104,7 @@ public class NewsServiceImpl implements NewsService {
             for (int attempt = 1; attempt <= RETRY_COUNT; attempt++) {
                 try {
                     doc = Jsoup.connect(url)
-                            .header("User-Agent", USER_AGENT)
+                            .header("User-Agent", getRandomUserAgent())
                             .header("Accept-Language", "en-US,en;q=0.5")
                             .header("Referer", "https://www.naver.com/")
                             .timeout(TIMEOUT)
@@ -107,7 +116,7 @@ public class NewsServiceImpl implements NewsService {
                         throw e; // 최대 재시도 횟수에 도달하면 예외를 던짐
                     }
                     try {
-                        TimeUnit.SECONDS.sleep(1); // 재시도 전 대기
+                        TimeUnit.SECONDS.sleep(3); // 재시도 전 대기
                     } catch (InterruptedException ie) {
                         Thread.currentThread().interrupt();
                         throw new IOException("Interrupted during retry delay", ie);
@@ -145,7 +154,7 @@ public class NewsServiceImpl implements NewsService {
             }
 
             try {
-                TimeUnit.SECONDS.sleep(1); // 다음 요청 전에 대기
+                TimeUnit.SECONDS.sleep(3); // 다음 요청 전에 대기
             } catch (InterruptedException e) {
                 Thread.currentThread().interrupt();
                 throw new IOException("Interrupted during sleep", e);
@@ -330,7 +339,7 @@ public class NewsServiceImpl implements NewsService {
         for (int attempt = 1; attempt <= RETRY_COUNT; attempt++) {
             try {
                 doc = Jsoup.connect(url)
-                        .header("User-Agent", USER_AGENT)
+                        .header("User-Agent", getRandomUserAgent())
                         .header("Accept-Language", "en-US,en;q=0.5")
                         .header("Referer", "https://www.naver.com/")
                         .timeout(TIMEOUT)
@@ -342,7 +351,7 @@ public class NewsServiceImpl implements NewsService {
                     throw e; // 최대 재시도 횟수에 도달하면 예외를 던짐
                 }
                 try {
-                    TimeUnit.SECONDS.sleep(1); // 재시도 전 대기
+                    TimeUnit.SECONDS.sleep(3); // 재시도 전 대기
                 } catch (InterruptedException ie) {
                     Thread.currentThread().interrupt();
                     throw new IOException("Interrupted during retry delay", ie);

--- a/src/main/java/org/likelion/newsfactbackend/domain/news/service/impl/NewsServiceImpl.java
+++ b/src/main/java/org/likelion/newsfactbackend/domain/news/service/impl/NewsServiceImpl.java
@@ -6,7 +6,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.apache.coyote.Response;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
@@ -34,7 +33,6 @@ import org.springframework.web.client.RestTemplate;
 import java.io.IOException;
 import java.util.*;
 import java.util.concurrent.TimeUnit;
-import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -56,15 +54,16 @@ public class NewsServiceImpl implements NewsService {
     private List<String> SIDS;
 
     private static final String BASE_URL = "https://search.naver.com/search.naver?where=news&query={search}&sm=tab_opt&sort=1&photo=0&field=0&pd=0&ds=&de=&docid=&related=0&mynews=1&office_type=1&office_section_code=3&news_office_checked={oid}&nso=so%3Add%2Cp%3Aall&is_sug_officeid=0&office_category=0&service_area=0";
-    private static final List<String> USER_AGENTS = List.of(
-            "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/58.0.3029.110 Safari/537.3",
-            "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/69.0.3497.100 Safari/537.36",
-            "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/70.0.3538.77 Safari/537.36"
-    );
+    @Value("${user.agent}")
+    private List<String> USER_AGENTS;
+
+
 
     private String getRandomUserAgent() {
         Random rand = new Random();
-        return USER_AGENTS.get(rand.nextInt(USER_AGENTS.size()));
+        String agent = USER_AGENTS.get(rand.nextInt(USER_AGENTS.size()));
+        log.info("[news] agent : {}", agent);
+        return agent;
     }
     private static final int TIMEOUT = 10000; // 10초
     private static final int RETRY_COUNT = 3; // 재시도 횟수


### PR DESCRIPTION
## 개요
- 다수가 동시에 주제 검색 시 튕김 버그 발생
- 다수가 동시에 동일한 리소스에서 naver news 접근 시 봇으로 간주하여 차단함
- 때문에, 여러 다양한 디바이스, 클라이언트에서 요청하게끔 인식 시켜야함
- 한 언론사 크롤링 후 다른 언론사 크롤링 시 쓰레드 3초 sleep

close #59

## PR 유형
어떤 변경 사항이 있나요?

- [ ] 새로운 기능 추가
- [x] 버그 수정
- [ ] CSS 등 사용자 UI 디자인 변경
- [x] 코드에 영향을 주지 않는 변경사항(오타 수정, 탭 사이즈 변경, 변수명 변경)
- [x] 코드 리팩토링
- [ ] 주석 추가 및 수정
- [ ] 문서 수정
- [ ] 테스트 추가, 테스트 리팩토링
- [ ] 빌드 부분 혹은 패키지 매니저 수정
- [ ] 파일 혹은 폴더명 수정
- [ ] 파일 혹은 폴더 삭제

## PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 오류가 없나요? 
- [x] 클린 코드를 작성했나요?
- [x] 개념있는 코드를 작성했나요?